### PR TITLE
fix last 4 digit display connect nav

### DIFF
--- a/components/Layout/Nav/AccountDisplay.js
+++ b/components/Layout/Nav/AccountDisplay.js
@@ -84,7 +84,7 @@ const AccountDisplay = () => {
               "..." +
               data.address.substring(
                 data.address.length - 5,
-                data.address.length - 1
+                data.address.length
               )
             : null}
         </button>


### PR DESCRIPTION
noticed my wallet address was missing the last character in the connect button, fixing that.