### PR TITLE
nullish check for icon from network -- prevent error on null network

### DIFF
--- a/components/Layout/Nav/NetworkIconDropdown.js
+++ b/components/Layout/Nav/NetworkIconDropdown.js
@@ -44,7 +44,7 @@ export default function NetworkIconDropdown() {
           className="nav-btn mr-3"
           onClick={handleOpen}
         >
-          {network.icon}
+          {network?.icon}
         </button>
         <NetworkDropdown isOpen={isDropdownOpen} onClick={handleClick} className="-translate-x-12" />
       </div>


### PR DESCRIPTION
noticed bbydao.xyz is down right now -- was getting the error on local too -- not sure why `network` is null right now, but just adding this line to prevent the error from happening