### PR TITLE
@theo/uniswap gnosis

### DIFF
--- a/components/Dao/Uniswap/RemoveLiquidity.js
+++ b/components/Dao/Uniswap/RemoveLiquidity.js
@@ -11,12 +11,14 @@ import { max256, NumberFromBig } from "utils/helpers"
 import { minimalABI } from "hooks/useERC20Contract"
 import { amount } from "./helpers"
 import useGnosisTransaction from "hooks/useGnosisTransaction"
+import useCalculateFee from "hooks/useCalculateFee"
 
 const RemoveLiquidity = ({ token }) => {
   const { data: signer } = useSigner()
   const queryClient = useQueryClient()
   const bbyDao = queryClient.getQueryData("expandedDao")
   const { gnosisTransaction } = useGnosisTransaction(bbyDao)
+  const { calculateFee } = useCalculateFee()
   const [breakDown, setBreakDown] = React.useState(undefined)
   const [toReceive, setToReceive] = React.useState({})
   const { state, setState, handleChange } = useForm()
@@ -113,6 +115,7 @@ const RemoveLiquidity = ({ token }) => {
             address: token0.address,
             name: token0.name,
             symbol: token0.symbol,
+            decimals: token0.decimals,
             priceInPair: priceOfToken0InToken1,
             amount: token0Amount,
           },
@@ -120,6 +123,7 @@ const RemoveLiquidity = ({ token }) => {
             address: token1.address,
             name: token1.name,
             symbol: token1.symbol,
+            decimals: token1.decimals,
             priceInPair: priceOfToken1InToken0,
             amount: token1Amount,
           },
@@ -164,9 +168,16 @@ const RemoveLiquidity = ({ token }) => {
     }
   }
 
-  const handleRemoveLiquidity = () => {
-    const amountAMin = ethers.utils.parseUnits((toReceive.token0 - toReceive.token0 * slippage).toString())
-    const amountBMin = ethers.utils.parseUnits((toReceive.token1 - toReceive.token1 * slippage).toString())
+  const handleRemoveLiquidity = async () => {
+    //undeflow issue because of slippage calculation, toFixed(6) feels a bit arbitrary, can find better solution
+    const amountAMin = ethers.utils.parseUnits(
+      (toReceive.token0 - toReceive.token0 * slippage).toFixed(6).toString(),
+      toReceive?.token0?.decimals
+    )
+    const amountBMin = ethers.utils.parseUnits(
+      (toReceive.token1 - toReceive.token1 * slippage).toFixed(6).toString(),
+      toReceive?.token1?.decimals
+    )
     const amountMins = {
       [breakDown.token0.symbol]: amountAMin,
       [breakDown.token1.symbol]: amountBMin,
@@ -196,7 +207,8 @@ const RemoveLiquidity = ({ token }) => {
           },
         },
         UniswapV2Router02,
-        0
+        0,
+        await calculateFee([{ value: amountTokenMin, token: pairToken }, { value: amountETHMin }])
       )
     } else {
       gnosisTransaction(
@@ -215,7 +227,11 @@ const RemoveLiquidity = ({ token }) => {
           },
         },
         UniswapV2Router02,
-        0
+        0,
+        await calculateFee([
+          { value: amountAMin, token: breakDown.token0 },
+          { value: amountBMin, token: breakDown.token1 },
+        ])
       )
     }
   }
@@ -304,11 +320,11 @@ const RemoveLiquidity = ({ token }) => {
 
                 <div className="flex justify-between">
                   <div>{breakDown?.token0?.symbol}: </div>
-                  <div>{Number((breakDown?.token0?.amount))?.toFixed(5)}</div>
+                  <div>{Number(breakDown?.token0?.amount)?.toFixed(5)}</div>
                 </div>
                 <div className="flex justify-between">
                   <div>{breakDown?.token1?.symbol}:</div>
-                  <div>{Number((breakDown?.token1?.amount))?.toFixed(5)}</div>
+                  <div>{Number(breakDown?.token1?.amount)?.toFixed(5)}</div>
                 </div>
               </>
             )}
@@ -317,7 +333,7 @@ const RemoveLiquidity = ({ token }) => {
             {breakDown && (
               <>
                 <div>Price</div>
-                <div className="text-sm text-right">
+                <div className="text-right text-sm">
                   <div>
                     1 {breakDown?.token0?.symbol} = {breakDown?.token0?.priceInPair} {breakDown?.token1?.symbol}
                   </div>
@@ -331,7 +347,7 @@ const RemoveLiquidity = ({ token }) => {
         </div>
       </div>
 
-      <div className="flex gap-4 my-6">
+      <div className="my-6 flex gap-4">
         {breakDown && (
           <button
             className={`focus:shadow-outline mt-4 h-16 w-full appearance-none rounded-full bg-slate-200
@@ -348,7 +364,7 @@ const RemoveLiquidity = ({ token }) => {
           <button
             onClick={() => handleRemoveLiquidity()}
             className={`focus:shadow-outline mt-4 h-16 w-full appearance-none rounded-full
-           bg-sky-500 hover:bg-sky-600 p-4 py-2 px-3 text-xl leading-tight focus:outline-none
+           bg-sky-500 p-4 py-2 px-3 text-xl leading-tight hover:bg-sky-600 focus:outline-none
           dark:bg-orange-600 dark:hover:bg-orange-700`}
           >
             Remove Liquidity

--- a/components/Dao/Uniswap/Swap.js
+++ b/components/Dao/Uniswap/Swap.js
@@ -370,9 +370,7 @@ const Swap = ({ token }) => {
       }
       const outputToken = {
         token: tokens.token1,
-        value: (parseFloat(token1.toString()) - parseFloat(token1.toString()) * slippage).toFixed(
-          tokens.token1.decimals
-        ),
+        value: parseFloat(token1.toString()) - parseFloat(token1.toString()) * slippage,
       }
       const swapExactTokensForTokens = inputToken.token.symbol !== "ETH" && outputToken.token.symbol !== "ETH"
       const swapExactETHForTokens = !isEthOnEth && inputToken.token.symbol === "ETH"
@@ -380,7 +378,7 @@ const Swap = ({ token }) => {
 
       if (isEthOnEth) {
         const WETHContract = new ethers.Contract(WETH, WETHABI, signer)
-        const wad = ethers.utils.parseUnits(inputToken.value.toString(), inputToken?.token?.decimals)
+        const wad = ethers.utils.parseUnits(inputToken.value.toFixed(6).toString(), inputToken?.token?.decimals)
         if (inputToken.token.symbol === "WETH") {
           const tx = gnosisTransaction(
             {
@@ -412,8 +410,8 @@ const Swap = ({ token }) => {
       }
 
       if (swapExactTokensForTokens) {
-        const amountIn = ethers.utils.parseUnits(inputToken.value.toString(), inputToken?.token?.decimals)
-        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toString(), outputToken?.token?.decimals)
+        const amountIn = ethers.utils.parseUnits(inputToken.value.toFixed(6).toString(), inputToken?.token?.decimals)
+        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toFixed(6).toString(), outputToken?.token?.decimals)
         let path
         if (poolExists) {
           path = [ethers.utils.getAddress(inputToken.token.address), ethers.utils.getAddress(outputToken.token.address)]
@@ -449,8 +447,8 @@ const Swap = ({ token }) => {
       }
 
       if (swapExactETHForTokens) {
-        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toString(), outputToken?.token?.decimals)
-        const value = ethers.utils.parseUnits(inputToken.value.toString())
+        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toFixed(6).toString(), outputToken?.token?.decimals)
+        const value = ethers.utils.parseUnits(inputToken.value.toFixed(6).toString())
         const tx = gnosisTransaction(
           {
             abi: IUniswapV2Router02["abi"],
@@ -471,8 +469,8 @@ const Swap = ({ token }) => {
       }
 
       if (swapExactTokensForETH) {
-        const amountIn = ethers.utils.parseUnits(inputToken.value.toString(), inputToken?.token?.decimals)
-        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toString(), outputToken?.token?.decimals)
+        const amountIn = ethers.utils.parseUnits(inputToken.value.toFixed(6).toString(), inputToken?.token?.decimals)
+        const amountOutMin = ethers.utils.parseUnits(outputToken.value.toFixed(6).toString(), outputToken?.token?.decimals)
         const tx = gnosisTransaction(
           {
             abi: IUniswapV2Router02["abi"],

--- a/hooks/useCalculateFee.js
+++ b/hooks/useCalculateFee.js
@@ -1,52 +1,63 @@
-import {ChainId, Fetcher, Token} from '@uniswap/sdk'
-import IUniswapV2Pair            from '@uniswap/v2-periphery/build/IUniswapV2Pair.json'
-import {ethers}                  from 'ethers'
-import React                     from 'react'
-import {useSigner}               from 'wagmi'
+import { ChainId, Fetcher, Token } from "@uniswap/sdk"
+import IUniswapV2Pair from "@uniswap/v2-periphery/build/IUniswapV2Pair.json"
+import { ethers } from "ethers"
+import React from "react"
+import { useSigner } from "wagmi"
 
 export default function useCalculateFee() {
-    const {data: signer} = useSigner()
+  const { data: signer } = useSigner()
+  const signerAddress = React.useMemo(() => {
+    return signer ? signer._address : null
+  }, [signer])
 
-    // tokens: Array of {value, token}
-    // value: BigNumber
-    // token: Object, {address, decimals, symbol, name} --- optional for WETH/ETH
-    const calculateFee = React.useCallback(async (tokens) => {
-        try {
-            let totalFee = 0
-            for(const t of tokens) {
-                const {token, value} = t
-                const WETH = ethers.utils.getAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
-                const percentage = 0.01
-                let fee
-
-                if (!token || token.address === WETH) {
-                    fee = parseFloat(ethers.utils.formatEther(value)) * percentage
-                    return ethers.utils.parseEther(fee.toString())
-                }
-
-                const token0 = new Token(ChainId.MAINNET, WETH, 18, "WETH", "Wrapped Ether")
-                const token1 = new Token(ChainId.MAINNET, token?.address, token?.decimals, token?.symbol, token?.name)
-                const uniPair = await Fetcher.fetchPairData(token0, token1)
-                const pairContract = new ethers.Contract(
-                    ethers.utils.getAddress(uniPair.liquidityToken.address),
-                    IUniswapV2Pair["abi"],
-                    signer
-                )
-                const reserves = await pairContract?.getReserves()
-                const priceOfWETHInToken = Number(
-                    (Number(reserves[0]) * token0.decimals) / (Number(reserves[1]) * token1.decimals)
-                ).toFixed(18)
-                const bigNumberPriceOfWETHInToken = ethers.utils.parseUnits((priceOfWETHInToken.toString()), token1.decimals)
-                const valueInEth =  (parseFloat(ethers.utils.formatEther(value)) / parseFloat(ethers.utils.formatEther(bigNumberPriceOfWETHInToken)))
-                fee = valueInEth * percentage
-                totalFee += fee
-            }
-            return ethers.utils.parseEther(totalFee.toString())
-
-        } catch (err) {
-            console.log("err", err)
+  // tokens: Array of {value, token}
+  // value: BigNumber
+  // token: Object, {address, decimals, symbol, name} --- optional for WETH/ETH
+  const calculateFee = React.useCallback(
+    async tokens => {
+      try {
+        if (!signerAddress) {
+          throw new Error("no signer address or no bbyDao Safe instance or safe SDK")
         }
-    }, [])
 
-    return {calculateFee}
+        let totalFee = 0
+        for (const t of tokens) {
+          const { token, value } = t
+          const WETH = ethers.utils.getAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+          const percentage = 0.01
+          let fee
+
+          if (!token || token.address === WETH) {
+            //to prevent underflow, feels arbitrary can find better fix that toFixed(6)
+            fee = (parseFloat(ethers.utils.formatEther(value)) * percentage).toFixed(6)
+            totalFee += parseFloat(fee.toString())
+
+          } else {
+            const token0 = new Token(ChainId.MAINNET, WETH, 18, "WETH", "Wrapped Ether")
+            const token1 = new Token(ChainId.MAINNET, token?.address, token?.decimals, token?.symbol, token?.name)
+            const uniPair = await Fetcher.fetchPairData(token0, token1)
+            const pairContract = new ethers.Contract(
+              ethers.utils.getAddress(uniPair.liquidityToken.address),
+              IUniswapV2Pair["abi"],
+              signer
+            )
+            const reserves = await pairContract?.getReserves()
+            const priceOfWETHInToken = (
+              parseFloat(ethers.utils.formatEther(reserves[0])) / parseFloat(ethers.utils.formatUnits(reserves[1], token1?.decimals))
+            ).toFixed(6) //to prevent underflow, feels arbitrary can find better fix that toFixed(6)
+
+            const valueInEth = parseFloat(ethers.utils.formatEther(value)) / priceOfWETHInToken
+            fee = valueInEth * percentage
+            totalFee += parseFloat(fee.toString())
+          }
+        }
+        return ethers.utils.parseEther(totalFee.toFixed(18))
+      } catch (err) {
+        console.log("err", err)
+      }
+    },
+    [signer]
+  )
+
+  return { calculateFee }
 }

--- a/hooks/useCalculateFee.js
+++ b/hooks/useCalculateFee.js
@@ -42,15 +42,19 @@ export default function useCalculateFee() {
               signer
             )
             const reserves = await pairContract?.getReserves()
+            const WETHReserve = uniPair?.tokenAmounts[0]?.token?.symbol === 'WETH' ? reserves[0] : reserves[1]
+            const PairReserve =  uniPair?.tokenAmounts[0]?.token?.symbol !== 'WETH' ? reserves[0] : reserves[1]
             const priceOfWETHInToken = (
-              parseFloat(ethers.utils.formatEther(reserves[0])) / parseFloat(ethers.utils.formatUnits(reserves[1], token1?.decimals))
+              parseFloat(ethers.utils.formatUnits(PairReserve, token1?.decimals)) / parseFloat(ethers.utils.formatEther(WETHReserve))
             ).toFixed(6) //to prevent underflow, feels arbitrary can find better fix that toFixed(6)
 
             const valueInEth = parseFloat(ethers.utils.formatEther(value)) / priceOfWETHInToken
+
             fee = valueInEth * percentage
             totalFee += parseFloat(fee.toString())
           }
         }
+
         return ethers.utils.parseEther(totalFee.toFixed(18))
       } catch (err) {
         console.log("err", err)


### PR DESCRIPTION
- calculation of fee in ETH is dependent on uniswaps `getReserves()` order of `reserves` changes between pairs, needed to ensure that when dividing token reserves / weth reserves -- that weth reserves is always the divisor -- fee should now be accurate