### PR TITLE
use uniswapv2 graph to measure liquidity

### DIFF
--- a/components/Dao/Uniswap/PoolInfo.js
+++ b/components/Dao/Uniswap/PoolInfo.js
@@ -4,8 +4,10 @@ import { minimalABI } from "hooks/useERC20Contract"
 import { eToNumber, isEmpty, max256, NumberFromBig } from "utils/helpers"
 import IUniswapV2Pair from "@uniswap/v2-periphery/build/IUniswapV2Pair.json"
 import useGnosisTransaction from "hooks/useGnosisTransaction"
+import { useDaoStore } from "stores/useDaoStore"
 
 const PoolInfo = ({ spender, pair, info, signer, hasAllowance, setHasAllowance, safeAddress }) => {
+  const uniswapV2GraphClient = useDaoStore(state => state.uniswapV2GraphClient)
   const { gnosisTransaction } = useGnosisTransaction(safeAddress)
   const token0 = info?.transactionInfo?.[0].token
   const token1 = info?.transactionInfo?.[1].token
@@ -140,6 +142,40 @@ const PoolInfo = ({ spender, pair, info, signer, hasAllowance, setHasAllowance, 
       console.log("err", err)
     }
   }, [token0, token1, signer])
+
+//   React.useMemo(async () => {
+//     const address = ethers.utils.getAddress(pair?.address).toLowerCase()
+//     const data = await uniswapV2GraphClient
+//       .query(
+//         `{
+//  pair(id: "${address}"){
+//      token0 {
+//        id
+//        symbol
+//        name
+//        derivedETH
+//      }
+//      token1 {
+//        id
+//        symbol
+//        name
+//        derivedETH
+//      }
+//      reserve0
+//      reserve1
+//      reserveUSD
+//      trackedReserveETH
+//      token0Price
+//      token1Price
+//      volumeUSD
+//      txCount
+//  }
+// }`
+//       )
+//       .toPromise()
+//
+//     console.log('d', parseFloat(data?.data?.pair?.reserveUSD))
+//   }, [uniswapV2GraphClient])
 
   /*
    *

--- a/components/Dao/Uniswap/Swap.js
+++ b/components/Dao/Uniswap/Swap.js
@@ -21,6 +21,8 @@ import Slippage from "../Slippage"
 import TokenSearch from "../TokenSearch"
 
 const Swap = ({ token }) => {
+  const bbyDao = usePlaygroundStore(state => state.expandedDao)
+  const signer = useLayoutStore(state => state.signer)
   const uniswapV2GraphClient = useDaoStore(state => state.uniswapV2GraphClient)
   const queryClient = useQueryClient()
   const token0InputRef = React.useRef()
@@ -29,17 +31,15 @@ const Swap = ({ token }) => {
   const [poolExists, setPoolExists] = React.useState(true)
   const [hasNoLiquidity, setHasNoLiquidity] = React.useState(false)
   const [isEthOnEth, setIsEthOnEth] = React.useState(false)
-  const bbyDao = usePlaygroundStore(state => state.expandedDao)
-  const signer = useLayoutStore(state => state.signer)
+  const [hasAllowance, setHasAllowance] = React.useState()
   const bbyDaoTokens = queryClient.getQueryData(["daoTokens", bbyDao])
   const { gnosisTransaction } = useGnosisTransaction(bbyDao)
-  const [hasAllowance, setHasAllowance] = React.useState()
-  const WETH = ethers.utils.getAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
-  const USDT = ethers.utils.getAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
-
-  const UniswapV2Router02 = ethers.utils.getAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
   const { state, setState, handleChange } = useForm()
   const { calculateFee } = useCalculateFee()
+  const WETH = ethers.utils.getAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+  const USDT = ethers.utils.getAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+  const UniswapV2Router02 = ethers.utils.getAddress("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+  const MIN_LIQUIDITY_USD = 10000
 
   /* Build Token List */
   const [coingeckoTokenList, setCoingeckoTokenList] = React.useState([])
@@ -240,7 +240,7 @@ const Swap = ({ token }) => {
           .toPromise()
 
         const poolReserves = parseFloat(data?.data?.pair?.reserveUSD)
-        const hasLiquidity = poolReserves > 10000 //
+        const hasLiquidity = poolReserves > MIN_LIQUIDITY_USD //must have at least 10,000 USD of liquidity
 
         if (!hasLiquidity) {
           if (!hasEth) {


### PR DESCRIPTION
- improve routing by using graphql to check for USD value of liqudity
- reroute through WETH if value of pool is less than 10,000 USD (this is arbitrary can improve perhaps)
- reroute through USDT if ETH if involved int rade